### PR TITLE
add api to remove users in the global scale setup

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -19,6 +19,7 @@ $app->add($container->get('BruteForceMiddleware'));
 $app->get('/users', 'UserManager:search');
 $app->post('/users', 'UserManager:register');
 $app->post('/gs/users', 'UserManager:batchRegister');
+$app->delete('/gs/users', 'UserManager:batchDelete');
 $app->delete('/users', 'UserManager:delete');
 $app->get('/validate/email/{token}', 'EmailValidator:validate')->setName('validateEmail');
 $app->get('/status', 'Status:status');

--- a/server/lib/UserManager.php
+++ b/server/lib/UserManager.php
@@ -364,7 +364,7 @@ LIMIT ' . $limit);
 	}
 
 	/**
-	 * let server auto register users, used in the global scale scenario
+	 * let Nextcloud servers auto register users, used in the global scale scenario
 	 *
 	 * @param Request $request
 	 * @param Response $response
@@ -380,7 +380,7 @@ LIMIT ' . $limit);
 		}
 
 		if ($body['authKey'] !== $this->authKey) {
-			$response->withStatus(400);
+			$response->withStatus(403);
 			return $response;
 		}
 
@@ -391,6 +391,36 @@ LIMIT ' . $limit);
 		return $response;
 
 	}
+
+	/**
+	 * let Nextcloud servers remove users from the lookup server, used in the global scale scenario
+	 *
+	 * @param Request $request
+	 * @param Response $response
+	 * @return Response
+	 */
+	public function batchDelete(Request $request, Response $response) {
+
+		$body = json_decode($request->getBody(), true);
+
+		if ($body === null || !isset($body['authKey']) || !isset($body['users'])) {
+			$response->withStatus(400);
+			return $response;
+		}
+
+		if ($body['authKey'] !== $this->authKey) {
+			$response->withStatus(403);
+			return $response;
+		}
+
+		foreach ($body['users'] as $cloudId) {
+			$this->deleteDBRecord($cloudId);
+		}
+
+		return $response;
+
+	}
+
 
 	public function delete(Request $request, Response $response) {
 		$body = json_decode($request->getBody(), true);


### PR DESCRIPTION
Add api to allow Nextcloud servers to remove users from the lookup server without user interaction, needed in the global scale scenario.

cc @MorrisJobke 