### PR TITLE
Lookup server matches email as well as userid

### DIFF
--- a/server/lib/UserManager.php
+++ b/server/lib/UserManager.php
@@ -135,45 +135,45 @@ class UserManager {
 	 * @return array
 	 */
 	private function performSearch($search, $exactMatch, $parameters, $minKarma) {
-                /**
-                 * We assume that we want to check for matches in both userid
-                 * and email. However, if the search string looks like an email
-                 * address, we check if there are multiple accounts with the same
-                 * email address registred. If so, we limit the search to userid.
-                 * We will never search the name keys.
-                 */
-                $searchKeys = ['userid', 'email'];
-                if (preg_match('/@\w?\w+(\.\w+)*$/', $search) === 1) {
-                        $numStmt = $this->db->prepare('SELECT count(*) as count FROM `store` WHERE v = :search AND k = "email"');
-                        $numStmt->bindParam('search', $search, \PDO::PARAM_STR);
-                        $numStmt->execute();
-                        $numResult = (int) $numStmt->fetch()['count'];
-                        $numStmt->closeCursor();
-                        if ($numResult > 1) {
-                                $searchKeys = ['userid'];
-                        }
-                }
-                $operator = $exactMatch ? ' = ' : ' LIKE ';
-                $limit = $exactMatch ? 1 : 50;
+		/**
+		 * We assume that we want to check for matches in both userid
+		 * and email. However, if the search string looks like an email
+		 * address, we check if there are multiple accounts with the same
+		 * email address registred. If so, we limit the search to userid.
+		 * We will never search the name keys.
+		 */
+		$searchKeys = ['userid', 'email'];
+		if (preg_match('/@\w?\w+(\.\w+)*$/', $search) === 1) {
+			$numStmt = $this->db->prepare('SELECT count(*) as count FROM `store` WHERE v = :search AND k = "email"');
+			$numStmt->bindParam('search', $search, \PDO::PARAM_STR);
+			$numStmt->execute();
+			$numResult = (int) $numStmt->fetch()['count'];
+			$numStmt->closeCursor();
+			if ($numResult > 1) {
+				$searchKeys = ['userid'];
+			}
+		}
+		$operator = $exactMatch ? ' = ' : ' LIKE ';
+		$limit = $exactMatch ? 1 : 50;
 
-                $constraint = '';
-                if (!empty($parameters)) {
-                        $constraint = 'AND (';
-                        $c = count($parameters);
-                        for ($i = 0; $i < $c; $i++) {
-                                if ($i !== 0) {
-                                        $constraint .= ' OR ';
-                                }
-                                $constraint .= '(k = :key' . $i . ')';
-                        }
-                        $constraint .= ')';
-                }
-                $constraint .= ' AND  (';
-                foreach ($searchKeys as $key) {
-                        $constraint .= 'k = "' . $key . '" OR ';
+		$constraint = '';
+		if (!empty($parameters)) {
+			$constraint = 'AND (';
+			$c = count($parameters);
+			for ($i = 0; $i < $c; $i++) {
+				if ($i !== 0) {
+					$constraint .= ' OR ';
+				}
+				$constraint .= '(k = :key' . $i . ')';
+			}
+			$constraint .= ')';
+		}
+		$constraint .= ' AND  (';
+		foreach ($searchKeys as $key) {
+			$constraint .= 'k = "' . $key . '" OR ';
 
-                }
-                $constraint = preg_replace('/" OR $/', '" )', $constraint);
+		}
+		$constraint = preg_replace('/" OR $/', '" )', $constraint);
 		$stmt = $this->db->prepare('SELECT *
 FROM (
 	SELECT userId AS userId, SUM(valid) AS karma

--- a/server/lib/UserManager.php
+++ b/server/lib/UserManager.php
@@ -164,7 +164,7 @@ FROM (
 	WHERE userId IN (
 		SELECT DISTINCT userId
 		FROM `store`
-		WHERE v ' . $operator . ' :search ' . $constraint . '
+		WHERE v ' . $operator . ' :search ' . $constraint .' AND k = "userid"
 	)
 	GROUP BY userId
 ) AS tmp


### PR DESCRIPTION
When there are several users accounts that share the same email address
AND the userid for one of those accounts is the same as the email
address, the lookup server will pick a user at random from those
accounts that share email address, causing the user to be logged in to
a random server.

This patch will make it so that usernames are only matched against the
userid, and not the email field.

Fixes: #75