### PR TITLE
returns static new response

### DIFF
--- a/server/lib/Replication.php
+++ b/server/lib/Replication.php
@@ -29,15 +29,13 @@ class Replication {
 		$userInfo = explode(':', $userInfo, 2);
 
 		if (count($userInfo) !== 2 || $userInfo[0] !== 'lookup' || $userInfo[1] !== $this->auth)  {
-			$response = $response->withStatus(401);
-			return $response;
+			return $response->withStatus(401);
 		}
 
 		$params = $request->getQueryParams();
 		if (!isset($params['timestamp'], $params['page']) || !ctype_digit($params['timestamp']) ||
 		    !ctype_digit($params['page'])) {
-			$response = $response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		$timestamp = (int)$params['timestamp'];

--- a/server/lib/UserManager.php
+++ b/server/lib/UserManager.php
@@ -5,8 +5,8 @@ namespace LookupServer;
 use LookupServer\Validator\Email;
 use LookupServer\Validator\Twitter;
 use LookupServer\Validator\Website;
-use \Psr\Http\Message\ServerRequestInterface as Request;
-use \Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 class UserManager {
 
@@ -72,8 +72,7 @@ class UserManager {
 		$params = $request->getQueryParams();
 
 		if (!isset($params['search']) || $params['search'] === '') {
-			$response->withStatus(404);
-			return $response;
+			return $response->withStatus(404);
 		}
 
 		$search = $params['search'];
@@ -363,8 +362,7 @@ LIMIT :limit');
 		if ($body === null || !isset($body['message']) || !isset($body['message']['data']) ||
 			!isset($body['message']['data']['federationId']) || !isset($body['signature']) ||
 			!isset($body['message']['timestamp'])) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		$cloudId = $body['message']['data']['federationId'];
@@ -372,18 +370,17 @@ LIMIT :limit');
 		try {
 			$verified = $this->signatureHandler->verify($cloudId, $body['message'], $body['signature']);
 		}  catch(\Exception $e) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		if ($verified) {
 			$result = $this->insertOrUpdate($cloudId, $body['message']['data'], $body['message']['timestamp']);
 			if ($result === false) {
-				$response->withStatus(403);
+			return $response->withStatus(403);
 			}
 		} else {
 			// ERROR OUT
-			$response->withStatus(403);
+			return $response->withStatus(403);
 		}
 
 		return $response;
@@ -401,13 +398,11 @@ LIMIT :limit');
 		$body = json_decode($request->getBody(), true);
 
 		if ($body === null || !isset($body['authKey']) || !isset($body['users'])) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		if ($body['authKey'] !== $this->authKey) {
-			$response->withStatus(403);
-			return $response;
+			return $response->withStatus(403);
 		}
 
 		foreach ($body['users'] as $cloudId => $data) {
@@ -430,13 +425,11 @@ LIMIT :limit');
 		$body = json_decode($request->getBody(), true);
 
 		if ($body === null || !isset($body['authKey']) || !isset($body['users'])) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		if ($body['authKey'] !== $this->authKey) {
-			$response->withStatus(403);
-			return $response;
+			return $response->withStatus(403);
 		}
 
 		foreach ($body['users'] as $cloudId) {
@@ -454,8 +447,7 @@ LIMIT :limit');
 		if ($body === null || !isset($body['message']) || !isset($body['message']['data']) ||
 			!isset($body['message']['data']['federationId']) || !isset($body['signature']) ||
 			!isset($body['message']['timestamp'])) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 		$cloudId = $body['message']['data']['federationId'];
@@ -463,19 +455,18 @@ LIMIT :limit');
 		try {
 			$verified = $this->signatureHandler->verify($cloudId, $body['message'], $body['signature']);
 		}  catch(\Exception $e) {
-			$response->withStatus(400);
-			return $response;
+			return $response->withStatus(400);
 		}
 
 
 		if ($verified) {
 			$result = $this->deleteDBRecord($cloudId);
 			if ($result === false) {
-				$response->withStatus(404);
+				return $response->withStatus(404);
 			}
 		} else {
 			// ERROR OUT
-			$response->withStatus(403);
+			return $response->withStatus(403);
 		}
 
 		return $response;

--- a/server/lib/Validator/Email.php
+++ b/server/lib/Validator/Email.php
@@ -2,8 +2,8 @@
 
 namespace LookupServer\Validator;
 
-use \Psr\Http\Message\ServerRequestInterface as Request;
-use \Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
 
 class Email {
 
@@ -54,8 +54,7 @@ class Email {
 		$stmt->closeCursor();
 
 		if ($validation === false) {
-			$response->withStatus(403);
-			$response->getBody()->write('Invalid token');
+			return $response->withStatus(403, 'Invalid token');
 		} else {
 			$stmt = $this->db->prepare('UPDATE store SET valid = 1 WHERE id = :storeId');
 			$stmt->bindParam('storeId', $validation['storeId']);


### PR DESCRIPTION
From what it seems, in Slim, `$response->withStatus()` does not update current `Response` status, but generate a new `Response` that needs to be returned instead of the original `Response`

fix #72