### PR TITLE
Add option to have lookup server on different base path then root

### DIFF
--- a/server/config/config.sample.php
+++ b/server/config/config.sample.php
@@ -8,6 +8,9 @@
 // Lookup-Server Config
 
 $CONFIG = [
+	// Application BASE Path. If the application is located under a subpath, define the path here.
+	'BASE_PATH' => '/lookup-server',
+
 	//DB
 	'DB' => [
 		'host' => 'localhost',

--- a/server/init.php
+++ b/server/init.php
@@ -19,19 +19,20 @@ define('VERSION', '1.1.2');
 
 
 require __DIR__ . '/vendor/autoload.php';
+$settings = require __DIR__ . '/src/config.php';
 
 $container = new Container();
 AppFactory::setContainer($container);
 $app = AppFactory::create();
-$app->setBasePath('');
 
-$settings = require __DIR__ . '/src/config.php';
 $container->set('Settings', function (Container $c) use ($settings) {
 	return $settings;
 });
+
+$basePath = $settings['settings']['base_path'] ?? '';
+$app->setBasePath($basePath);
 
 $container->set('DependenciesService', function (Container $c) {
 	return new DependenciesService($c->get('Settings'));
 });
 $container->get('DependenciesService')->initContainer($container, $app);
-

--- a/server/src/config.php
+++ b/server/src/config.php
@@ -11,6 +11,7 @@ return [
 	'settings' => [
 		'displayErrorDetails' => true,
 		'addContentLengthHeader' => true,
+		'base_path' => $CONFIG['BASE_PATH'] ?? '',
 		'db' => [
 			'host' => $CONFIG['DB']['host'] ?? 'localhost',
 			'user' => $CONFIG['DB']['user'] ?? 'lookup',


### PR DESCRIPTION
Currently, the application must be deployed to the root domain by default. 
However, if you want to have it in a subfolder, it is useful to be able to configure this directly. 
For example, at the endpoint: your-domain.com/lookup-server/