### PR TITLE
fix: add unique constraint for users.federationId and cleanup scripts for existing installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ The Lookup-Server is a server component that can be run independently from an Ne
 
 Please look into the [doc](./doc) directory for more information.
 
+## Duplicate `federationId` entries on `users` table
+
+In some cases, due to race condition, duplicate entries may have been inserted into the `users` table, meaning more than one row with the same `federationId`. While this does not cause any critical issues, it can lead to unnecessary database growth over time.
+
+Since this was reported, a `UNIQUE KEY` constraint has been added to `users.federationId` in `mysql.dmp`, preventing this from happening on new installations.
+
+If your installation was set up before this change, two SQL scripts are available under `sql/` to help you fix this:
+
+1. `sql/cleanup_duplicate_users.sql` - removes entries with duplicated `federationId`, keeping the most recent one
+2. `sql/add_unique_federationId.sql` - adds the unique constraint on `users.federationId`
+
+`cleanup_duplicate_users.sql` should be run before `add_unique_federationId.sql`, since the unique constraint cannot be added while duplicates exist.
+
+Scripts can be run like:
+```bash
+mysql -h database_host -u username -p database_name < sql/cleanup_duplicate_users.sql
+```
+
+> Even though data in these tables is regenerated upon new user creation/login, it is advised to back up your database before running the scripts.
+
 ## License
 
 This code is licensed as AGPL v3 or later.

--- a/mysql.dmp
+++ b/mysql.dmp
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `federationId` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `federationId` (`federationId`(191))
+  UNIQUE KEY `federationId` (`federationId`(191))
 ) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 DROP TABLE IF EXISTS `instances`;

--- a/sql/add_unique_federationId.sql
+++ b/sql/add_unique_federationId.sql
@@ -1,0 +1,4 @@
+-- SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+ALTER TABLE users DROP INDEX `federationId`, ADD UNIQUE KEY `federationId` (`federationId`(191));

--- a/sql/cleanup_duplicate_users.sql
+++ b/sql/cleanup_duplicate_users.sql
@@ -1,0 +1,27 @@
+-- SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+-- keep one id per federationId, prioritizing the most recent timestamp and highest id
+CREATE TEMPORARY TABLE kept (id INT UNSIGNED PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO kept (id)
+SELECT id FROM (
+    SELECT id,
+        ROW_NUMBER() OVER (
+            PARTITION BY federationId
+            ORDER BY timestamp DESC, id DESC
+        ) AS rn
+    FROM users
+) ranked WHERE rn = 1;
+
+-- collect all duplicate ids to be deleted
+CREATE TEMPORARY TABLE duplicates (id INT UNSIGNED PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO duplicates (id)
+SELECT u.id FROM users u
+LEFT JOIN kept k ON u.id = k.id
+WHERE k.id IS NULL;
+
+-- delete duplicate entries from store and users
+START TRANSACTION;
+DELETE s FROM store s INNER JOIN duplicates d ON s.userId = d.id;
+DELETE u FROM users u INNER JOIN duplicates d ON u.id = d.id;
+COMMIT;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/lookup-server/issues/182

## Summary
- in some cases, due to a race condition, duplicate entries may have been inserted into the `users` table, meaning more than one row with the same `federationId`
- while this does not cause any critical issues, it can lead to unnecessary database growth over time
- this PR adds a `UNIQUE KEY` constraint on `users.federationId` in `mysql.dmp` to prevent this on new installations
- since the DB setup is done via `mysql.dmp` and there is no migration system in place, a similar approach was followed for existing installations: two new SQL scripts were provided under `sql/` folder, one to clean up duplicates and one to apply the constraint
- a new section was added to the README documenting the issue, the scripts, and how to use them

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI